### PR TITLE
:zap: update the node/actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 19.x
-        uses: actions/setup-node@v2.5.2
+        uses: actions/setup-node@v2.5.5
         with:
           node-version: 19.x
           cache: 'npm'


### PR DESCRIPTION
this will make the gh action work fine, as the old version has deprecated 