### PR TITLE
fix typo, and remove the env from starting job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,6 @@ jobs:
   build_crawler:
     name: Running the Crawler
     runs-on: ubuntu-latest
-    env:
-      MAIN_DATABASE_URL: ${{ secrets.MAIN_DATABASE_URL }}
-      LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
-      LIMIT: ${{ secrets.LIMIT }}
-      TITLES: ${{ secrets.TITLES }}
-      LOCATION: ${{ secrets.LOCATION }}
     
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +34,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Backend'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -71,7 +65,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Frontend'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -100,7 +94,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Software Engineer'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -129,7 +123,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Backend'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -158,7 +152,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Backend'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -187,7 +181,7 @@ jobs:
       LI_AT_COOKIE: ${{ secrets.LI_AT_COOKIE }}
       LIMIT: ${{ secrets.LIMIT }}
       TITLES: 'Software Engineer'
-      LOCATION: 'Egypt'
+      LOCATIONS: 'Egypt'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- read the args to run a spcific type of scrapper
- running concurrent jobs
- hotfix: missing the path to upload
- refactor: unuse the artifact and checkout øn eachjob
- remove env from start job, fix typos in env
